### PR TITLE
Url Encode returnUrl, and redirect upon login success.

### DIFF
--- a/MVC and API/src/IdentityServer/UI/Login/LoginController.cs
+++ b/MVC and API/src/IdentityServer/UI/Login/LoginController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http.Authentication;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Linq;
+using System.Net;
 using System.Security.Claims;
 using System.Threading.Tasks;
 
@@ -92,7 +93,7 @@ namespace Host.UI.Login
         {
             return new ChallengeResult(provider, new AuthenticationProperties
             {
-                RedirectUri = "/ui/external-callback?returnUrl=" + returnUrl
+                RedirectUri = "/ui/external-callback?returnUrl=" + WebUtility.UrlEncode(returnUrl)
             });
         }
 
@@ -133,12 +134,10 @@ namespace Host.UI.Login
 
             if (returnUrl != null)
             {
-                // todo: signin
-                //return new SignInResult(signInId);
+                return Redirect(returnUrl);
             }
 
             return Redirect("~/");
-
         }
     }
 }


### PR DESCRIPTION
This is a fix for https://github.com/IdentityServer/IdentityServer4/issues/217, which was reported in the wrong repo, IMO. The return url was not being used, presumably because the value of the returnUrl was wrong after signing in. This is because the return url was not being url-encoded, which caused the query parameters of the redirectUrl to flatten in to the query parameters of the uri containing the redirectUrl.

The net effect of this issue was that Identity Server Clients which depended on OpenID Connect were only being redirected back to the Client application if the user has previously authenticated with the Identity Server. i.e: the user would need to click "login" on the Client application, authenticate with an external provider, *manually* redirect back to the client application, and click "login" again to see the Identity Server consent page.

I'm url-encoding the return url before appending it to the redirect uri. I'm also taking the liberty to redirect to said return url upon successful login.