### PR TITLE
QS6 and Combined. Regression fixes for login UI and BL

### DIFF
--- a/Quickstarts/6_AspNetIdentity/src/IdentityServerWithAspNetIdentity/Controllers/AccountController.cs
+++ b/Quickstarts/6_AspNetIdentity/src/IdentityServerWithAspNetIdentity/Controllers/AccountController.cs
@@ -62,6 +62,11 @@ namespace IdentityServerWithAspNetIdentity.Controllers
             // Clear the existing external cookie to ensure a clean login process
             await HttpContext.SignOutAsync(IdentityConstants.ExternalScheme);
 
+            if (context?.IdP != null && (await _signInManager.GetExternalAuthenticationSchemesAsync()).Any(p => string.Equals(p.Name, context.IdP, StringComparison.InvariantCultureIgnoreCase)))
+            {
+                return ExternalLogin(context.IdP, returnUrl);
+            }
+
             ViewData["ReturnUrl"] = returnUrl;
             return View();
         }

--- a/Quickstarts/6_AspNetIdentity/src/IdentityServerWithAspNetIdentity/Views/Account/Login.cshtml
+++ b/Quickstarts/6_AspNetIdentity/src/IdentityServerWithAspNetIdentity/Views/Account/Login.cshtml
@@ -71,7 +71,7 @@
                             <p>
                                 @foreach (var provider in loginProviders)
                                 {
-                                    <button type="submit" class="btn btn-default" name="provider" value="@provider.Name" title="Log in using your @provider.DisplayName account">@provider.Name</button>
+                                    <button type="submit" class="btn btn-default" name="provider" value="@provider.Name" title="Log in using your @provider.DisplayName account">@provider.DisplayName</button>
                                 }
                             </p>
                         </div>

--- a/Quickstarts/Combined_AspNetIdentity_and_EntityFrameworkStorage/src/IdentityServerWithAspIdAndEF/Controllers/AccountController.cs
+++ b/Quickstarts/Combined_AspNetIdentity_and_EntityFrameworkStorage/src/IdentityServerWithAspIdAndEF/Controllers/AccountController.cs
@@ -62,6 +62,11 @@ namespace IdentityServerWithAspNetIdentity.Controllers
             // Clear the existing external cookie to ensure a clean login process
             await HttpContext.SignOutAsync(IdentityConstants.ExternalScheme);
 
+            if (context?.IdP != null && (await _signInManager.GetExternalAuthenticationSchemesAsync()).Any(p => string.Equals(p.Name, context.IdP, StringComparison.InvariantCultureIgnoreCase)))
+            {
+                return ExternalLogin(context.IdP, returnUrl);
+            }
+
             ViewData["ReturnUrl"] = returnUrl;
             return View();
         }

--- a/Quickstarts/Combined_AspNetIdentity_and_EntityFrameworkStorage/src/IdentityServerWithAspIdAndEF/Views/Account/Login.cshtml
+++ b/Quickstarts/Combined_AspNetIdentity_and_EntityFrameworkStorage/src/IdentityServerWithAspIdAndEF/Views/Account/Login.cshtml
@@ -71,7 +71,7 @@
                             <p>
                                 @foreach (var provider in loginProviders)
                                 {
-                                    <button type="submit" class="btn btn-default" name="provider" value="@provider.Name" title="Log in using your @provider.DisplayName account">@provider.Name</button>
+                                    <button type="submit" class="btn btn-default" name="provider" value="@provider.Name" title="Log in using your @provider.DisplayName account">@provider.DisplayName</button>
                                 }
                             </p>
                         </div>


### PR DESCRIPTION
Regression. Enabled back idp:name_of_idp bypasses the login/home realm screen and forwards the user directly to the selected identity provider.
Display name is used on external login provider buttons.