### PR TITLE
Fix the Authorize attribute

### DIFF
--- a/Quickstarts/Combined_AspNetIdentity_and_EntityFrameworkStorage/src/IdentityServerWithAspIdAndEF/Quickstart/Grants/GrantsController.cs
+++ b/Quickstarts/Combined_AspNetIdentity_and_EntityFrameworkStorage/src/IdentityServerWithAspIdAndEF/Quickstart/Grants/GrantsController.cs
@@ -16,7 +16,7 @@ namespace IdentityServer4.Quickstart.UI
     /// This sample controller allows a user to revoke grants given to clients
     /// </summary>
     [SecurityHeaders]
-    [Authorize(AuthenticationSchemes = IdentityServer4.IdentityServerConstants.DefaultCookieAuthenticationScheme)]
+    [Authorize]
     public class GrantsController : Controller
     {
         private readonly IIdentityServerInteractionService _interaction;


### PR DESCRIPTION
The Authorize attribute should be assigned to AspNetIdentity scheme or don't specify AuthenticationSchemes like in others controllers.