### PR TITLE
Update IdentityServer4 in Quickstart 7 so that it will build

### DIFF
--- a/Quickstarts/7_JavaScriptClient/src/QuickstartIdentityServer/QuickstartIdentityServer.csproj
+++ b/Quickstarts/7_JavaScriptClient/src/QuickstartIdentityServer/QuickstartIdentityServer.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityServer4" Version="2.0.0" />
+    <PackageReference Include="IdentityServer4" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Quickstart 7 does not build at the moment because the version of the IdentityServer4 NuGet package referenced in `QuickstartIdentityServer.csproj` is too old. This was reported [here](https://github.com/IdentityServer/IdentityServer4/issues/2125). This PR fixes it. 