### PR TITLE
Added claimsaction to map website claim (#1)

### DIFF
--- a/Quickstarts/5_HybridFlowAuthenticationWithApiAccess/src/MvcClient/Startup.cs
+++ b/Quickstarts/5_HybridFlowAuthenticationWithApiAccess/src/MvcClient/Startup.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using System.IdentityModel.Tokens.Jwt;
@@ -35,6 +36,7 @@ namespace MvcClient
 
                     options.Scope.Add("api1");
                     options.Scope.Add("offline_access");
+                    options.ClaimActions.MapJsonKey("website", "website");
                 });
         }
 


### PR DESCRIPTION
There is a lot of confusion on how to add extra claims using a hybrid flow since core 2.0 and this sample (no 5) is being used as a start of point for many. Thus I thought it would be a good idea to map the website claim present on the test users i the sample. It would also be coherent with the claims shown on previous samples. 