### PR TITLE
Fixed seeding in Program.Main in QS9/CombinedAspNetIdentity_EF

### DIFF
--- a/Quickstarts/Combined_AspNetIdentity_and_EntityFrameworkStorage/src/IdentityServerWithAspIdAndEF/Program.cs
+++ b/Quickstarts/Combined_AspNetIdentity_and_EntityFrameworkStorage/src/IdentityServerWithAspIdAndEF/Program.cs
@@ -34,7 +34,7 @@ namespace IdentityServerWithAspIdAndEF
 
             var host = BuildWebHost(args);
 
-            if (seed)
+            if (!seed)
             {
                 SeedData.EnsureSeedData(host.Services);
             }


### PR DESCRIPTION
In the `Combined_AspNetIdentity_and_EntityFramework` QS, the sqlite db was not getting seeded. A bool check needed to be inverted to ensure that the `IdentityServerWithAspIdAndEF.SeedData.EnsureSeedData` was called.