### PR TITLE
Netcore2.1 config

### DIFF
--- a/Quickstarts/6_AspNetIdentity/src/Api/Startup.cs
+++ b/Quickstarts/6_AspNetIdentity/src/Api/Startup.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -14,14 +16,22 @@ namespace Api
                 .AddAuthorization()
                 .AddJsonFormatters();
 
-            services.AddAuthentication("Bearer")
-                .AddIdentityServerAuthentication(options =>
-                {
-                    options.Authority = "http://localhost:5000";
-                    options.RequireHttpsMetadata = false;
+            services
+            .AddAuthentication(GetAuthenticationOptions)
+            .AddJwtBearer(GetJwtBearerOptions);
+        }
 
-                    options.ApiName = "api1";
-                });
+        private void GetAuthenticationOptions(AuthenticationOptions options)
+        {
+            options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+            options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+        }
+
+        private void GetJwtBearerOptions(JwtBearerOptions options)
+        {
+            options.Authority = "http://localhost:5001/";
+            options.Audience = "api1";
+            options.RequireHttpsMetadata = false;
         }
 
         public void Configure(IApplicationBuilder app)

--- a/Quickstarts/6_AspNetIdentity/src/IdentityServerWithAspNetIdentity/Startup.cs
+++ b/Quickstarts/6_AspNetIdentity/src/IdentityServerWithAspNetIdentity/Startup.cs
@@ -35,6 +35,23 @@ namespace IdentityServerWithAspNetIdentity
                             .AddSignInManager<SignInManager<ApplicationUser>>()
                             .AddDefaultTokenProviders();
 
+            services.AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = IdentityConstants.ApplicationScheme;
+                options.DefaultChallengeScheme = IdentityConstants.ApplicationScheme;
+                options.DefaultSignInScheme = IdentityConstants.ExternalScheme;
+            }).AddCookie(IdentityConstants.ApplicationScheme, options =>
+            {
+                options.Cookie.HttpOnly = true;
+                options.ExpireTimeSpan = TimeSpan.FromHours(1);
+                options.LoginPath = "/Account/Signin";
+                options.LogoutPath = "/Account/Signout";
+            }).AddCookie(IdentityConstants.ExternalScheme, o =>
+            {
+                o.Cookie.Name = IdentityConstants.ExternalScheme;
+                o.ExpireTimeSpan = TimeSpan.FromMinutes(5.0);
+            });
+
             services.AddMvc();
 
             services.Configure<IISOptions>(iis =>

--- a/Quickstarts/6_AspNetIdentity/src/IdentityServerWithAspNetIdentity/Startup.cs
+++ b/Quickstarts/6_AspNetIdentity/src/IdentityServerWithAspNetIdentity/Startup.cs
@@ -29,9 +29,11 @@ namespace IdentityServerWithAspNetIdentity
             services.AddDbContext<ApplicationDbContext>(options =>
                 options.UseSqlite(Configuration.GetConnectionString("DefaultConnection")));
 
-            services.AddIdentity<ApplicationUser, IdentityRole>()
-                .AddEntityFrameworkStores<ApplicationDbContext>()
-                .AddDefaultTokenProviders();
+            services.AddIdentityCore<ApplicationUser>(options => { })
+                            .AddRoles<IdentityRole>()
+                            .AddEntityFrameworkStores<ApplicationDbContext>()
+                            .AddSignInManager<SignInManager<ApplicationUser>>()
+                            .AddDefaultTokenProviders();
 
             services.AddMvc();
 
@@ -61,13 +63,6 @@ namespace IdentityServerWithAspNetIdentity
             {
                 throw new Exception("need to configure key material");
             }
-
-            services.AddAuthentication()
-              .AddGoogle(options =>
-              {
-                  options.ClientId = "708996912208-9m4dkjb5hscn7cjrn5u0r4tbgkbj1fko.apps.googleusercontent.com";
-                  options.ClientSecret = "wdfPY6t8H8cecgjlxud__4Gh";
-              });
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)


### PR DESCRIPTION
To avoid people searching across 20 different github posts, I made a set up which is required for net core 2.0 and 2.1 with jwt bearer auth. Microsofts net core 2.0 AddIdentity rewrites authentication schema when used with their default, so instead of AddIdentity we are for now required to use AddIdentityCore which does not overwrite authentication schema. I put all required settings, which will help anyone who will read samples. Current settings are highly outdated and unfortunately do not work with core 2.0 and 2.1.